### PR TITLE
Lint GitHub Actions workflows with actionlint

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,18 @@
+self-hosted-runner:
+  # Labels of Compiler Explorer's self-hosted runners (see the ce-ci repository)
+  labels:
+    - ce
+    - small
+    - medium
+    - admin
+    - lin-builder
+    - win-builder
+
+# Enforce shellcheck errors and warnings in embedded run: scripts, but not
+# info/style — consistent with the org-wide actionlint rollout.
+paths:
+  .github/workflows/**/*.yml:
+    ignore: &shellcheck-info-style
+      - 'shellcheck reported issue in this script: SC\d+:(info|style):'
+  .github/workflows/**/*.yaml:
+    ignore: *shellcheck-info-style

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,20 @@
+name: Lint GitHub Actions workflows
+
+on:
+  push:
+    branches: [main]
+    paths: ['.github/workflows/**', '.github/actionlint.yaml']
+  pull_request:
+    paths: ['.github/workflows/**', '.github/actionlint.yaml']
+
+jobs:
+  actionlint:
+    if: github.repository_owner == 'compiler-explorer'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color


### PR DESCRIPTION
Part of the org-wide [actionlint](https://github.com/rhysd/actionlint) rollout (see compiler-explorer/compiler-workflows#68, compiler-explorer/infra#2226, compiler-explorer/compiler-explorer#8912). Checks workflow files for schema errors, expression-context mistakes, unknown runner labels, and shellcheck issues (errors+warnings; info/style gated in `.github/actionlint.yaml`) on any push/PR touching them.

Existing workflows already passed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)